### PR TITLE
Consolidate TypeMapArrayIterator bad method tests

### DIFF
--- a/src/Model/TypeMapArrayIterator.php
+++ b/src/Model/TypeMapArrayIterator.php
@@ -47,11 +47,23 @@ class TypeMapArrayIterator extends ArrayIterator
         $this->typeMap = $typeMap;
     }
 
+    /**
+     * Not supported.
+     *
+     * @see http://php.net/arrayiterator.append
+     * @throws BadMethodCallException
+     */
     public function append($value)
     {
         throw BadMethodCallException::classIsImmutable(__CLASS__);
     }
 
+    /**
+     * Not supported.
+     *
+     * @see http://php.net/arrayiterator.asort
+     * @throws BadMethodCallException
+     */
     public function asort()
     {
         throw BadMethodCallException::classIsImmutable(__CLASS__);
@@ -68,16 +80,34 @@ class TypeMapArrayIterator extends ArrayIterator
         return \MongoDB\apply_type_map_to_document(parent::current(), $this->typeMap);
     }
 
+    /**
+     * Not supported.
+     *
+     * @see http://php.net/arrayiterator.ksort
+     * @throws BadMethodCallException
+     */
     public function ksort()
     {
         throw BadMethodCallException::classIsImmutable(__CLASS__);
     }
 
+    /**
+     * Not supported.
+     *
+     * @see http://php.net/arrayiterator.natcasesort
+     * @throws BadMethodCallException
+     */
     public function natcasesort()
     {
         throw BadMethodCallException::classIsImmutable(__CLASS__);
     }
 
+    /**
+     * Not supported.
+     *
+     * @see http://php.net/arrayiterator.natsort
+     * @throws BadMethodCallException
+     */
     public function natsort()
     {
         throw BadMethodCallException::classIsImmutable(__CLASS__);
@@ -87,6 +117,7 @@ class TypeMapArrayIterator extends ArrayIterator
      * Return the value from the provided offset with the type map applied.
      *
      * @see http://php.net/arrayiterator.offsetget
+     * @param mixed $offset
      * @return array|object
      */
     public function offsetGet($offset)
@@ -94,21 +125,45 @@ class TypeMapArrayIterator extends ArrayIterator
         return \MongoDB\apply_type_map_to_document(parent::offsetGet($offset), $this->typeMap);
     }
 
+    /**
+     * Not supported.
+     *
+     * @see http://php.net/arrayiterator.offsetset
+     * @throws BadMethodCallException
+     */
     public function offsetSet($index, $newval)
     {
         throw BadMethodCallException::classIsImmutable(__CLASS__);
     }
 
+    /**
+     * Not supported.
+     *
+     * @see http://php.net/arrayiterator.offsetunset
+     * @throws BadMethodCallException
+     */
     public function offsetUnset($index)
     {
         throw BadMethodCallException::classIsImmutable(__CLASS__);
     }
 
+    /**
+     * Not supported.
+     *
+     * @see http://php.net/arrayiterator.uasort
+     * @throws BadMethodCallException
+     */
     public function uasort($cmp_function)
     {
         throw BadMethodCallException::classIsImmutable(__CLASS__);
     }
 
+    /**
+     * Not supported.
+     *
+     * @see http://php.net/arrayiterator.uksort
+     * @throws BadMethodCallException
+     */
     public function uksort($cmp_function)
     {
         throw BadMethodCallException::classIsImmutable(__CLASS__);

--- a/tests/Model/TypeMapArrayIteratorTest.php
+++ b/tests/Model/TypeMapArrayIteratorTest.php
@@ -85,14 +85,14 @@ class TypeMapArrayIteratorTest extends TestCase
         $iterator->rewind();
 
         $iterator->asort();
-
     }
 
     /**
+     * @dataProvider provideMutateMethods
      * @expectedException MongoDB\Exception\BadMethodCallException
      * @expectedExceptionMessage MongoDB\Model\TypeMapArrayIterator is immutable
      */
-    public function testAsortThrowsException()
+    public function testMutateMethodsCannotBeCalled($method, $args)
     {
         $document = [
             'array' => [1, 2, 3],
@@ -107,220 +107,23 @@ class TypeMapArrayIteratorTest extends TestCase
 
         $iterator = new TypeMapArrayIterator([$document], $typeMap);
 
-        $expectedDocument = (object) [
-            'array' => [1, 2, 3],
-            'object' => (object) ['foo' => 'bar'],
-        ];
-
         $iterator->rewind();
 
-        $iterator->asort();
+        call_user_func_array([$iterator, $method], $args);
     }
 
-    /**
-     * @expectedException MongoDB\Exception\BadMethodCallException
-     * @expectedExceptionMessage MongoDB\Model\TypeMapArrayIterator is immutable
-     */
-    public function testKsortThrowsException()
+    public function provideMutateMethods()
     {
-        $document = [
-            'array' => [1, 2, 3],
-            'object' => ['foo' => 'bar'],
+        return [
+            ['append', [['x' => 1]]],
+            ['asort', []],
+            ['ksort', []],
+            ['natcasesort', []],
+            ['natsort', []],
+            ['offsetSet', [0, ['x' => 1]]],
+            ['offsetUnset', [0]],
+            ['uasort', [function($a, $b) { return 0; }]],
+            ['uksort', [function($a, $b) { return 0; }]],
         ];
-
-        $typeMap = [
-            'root' => 'object',
-            'document' => 'object',
-            'array' => 'array',
-        ];
-
-        $iterator = new TypeMapArrayIterator([$document], $typeMap);
-
-        $expectedDocument = (object) [
-            'array' => [1, 2, 3],
-            'object' => (object) ['foo' => 'bar'],
-        ];
-
-        $iterator->rewind();
-
-        $iterator->ksort();
-    }
-
-    /**
-     * @expectedException MongoDB\Exception\BadMethodCallException
-     * @expectedExceptionMessage MongoDB\Model\TypeMapArrayIterator is immutable
-     */
-    public function testNatcasessortThrowsException()
-    {
-        $document = [
-            'array' => [1, 2, 3],
-            'object' => ['foo' => 'bar'],
-        ];
-
-        $typeMap = [
-            'root' => 'object',
-            'document' => 'object',
-            'array' => 'array',
-        ];
-
-        $iterator = new TypeMapArrayIterator([$document], $typeMap);
-
-        $expectedDocument = (object) [
-            'array' => [1, 2, 3],
-            'object' => (object) ['foo' => 'bar'],
-        ];
-
-        $iterator->rewind();
-
-        $iterator->natcasesort();
-    }
-
-    /**
-     * @expectedException MongoDB\Exception\BadMethodCallException
-     * @expectedExceptionMessage MongoDB\Model\TypeMapArrayIterator is immutable
-     */
-    public function testNatsortThrowsException()
-    {
-        $document = [
-            'array' => [1, 2, 3],
-            'object' => ['foo' => 'bar'],
-        ];
-
-        $typeMap = [
-            'root' => 'object',
-            'document' => 'object',
-            'array' => 'array',
-        ];
-
-        $iterator = new TypeMapArrayIterator([$document], $typeMap);
-
-        $expectedDocument = (object) [
-            'array' => [1, 2, 3],
-            'object' => (object) ['foo' => 'bar'],
-        ];
-
-        $iterator->rewind();
-
-        $iterator->natsort();
-    }
-
-    /**
-     * @expectedException MongoDB\Exception\BadMethodCallException
-     * @expectedExceptionMessage MongoDB\Model\TypeMapArrayIterator is immutable
-     */
-    public function testOffsetSetThrowsException()
-    {
-        $document = [
-            'array' => [1, 2, 3],
-            'object' => ['foo' => 'bar'],
-        ];
-
-        $typeMap = [
-            'root' => 'object',
-            'document' => 'object',
-            'array' => 'array',
-        ];
-
-        $iterator = new TypeMapArrayIterator([$document], $typeMap);
-
-        $expectedDocument = (object) [
-            'array' => [1, 2, 3],
-            'object' => (object) ['foo' => 'bar'],
-        ];
-
-        $iterator->rewind();
-
-        $iterator->offsetSet(0, 3);
-    }
-
-    /**
-     * @expectedException MongoDB\Exception\BadMethodCallException
-     * @expectedExceptionMessage MongoDB\Model\TypeMapArrayIterator is immutable
-     */
-    public function testOffsetUnsetThrowsException()
-    {
-        $document = [
-            'array' => [1, 2, 3],
-            'object' => ['foo' => 'bar'],
-        ];
-
-        $typeMap = [
-            'root' => 'object',
-            'document' => 'object',
-            'array' => 'array',
-        ];
-
-        $iterator = new TypeMapArrayIterator([$document], $typeMap);
-
-        $expectedDocument = (object) [
-            'array' => [1, 2, 3],
-            'object' => (object) ['foo' => 'bar'],
-        ];
-
-        $iterator->rewind();
-
-        $iterator->offsetUnset(0);
-    }
-
-    /**
-     * @expectedException MongoDB\Exception\BadMethodCallException
-     * @expectedExceptionMessage MongoDB\Model\TypeMapArrayIterator is immutable
-     */
-    public function testUasortThrowsException()
-    {
-        $document = [
-            'array' => [1, 2, 3],
-            'object' => ['foo' => 'bar'],
-        ];
-
-        $typeMap = [
-            'root' => 'object',
-            'document' => 'object',
-            'array' => 'array',
-        ];
-
-        $iterator = new TypeMapArrayIterator([$document], $typeMap);
-
-        $expectedDocument = (object) [
-            'array' => [1, 2, 3],
-            'object' => (object) ['foo' => 'bar'],
-        ];
-
-        $iterator->rewind();
-        $cmp_function = function($a, $b) {
-            return $a;
-        };
-        $iterator->uasort($cmp_function(0, 1));
-    }
-
-    /**
-     * @expectedException MongoDB\Exception\BadMethodCallException
-     * @expectedExceptionMessage MongoDB\Model\TypeMapArrayIterator is immutable
-     */
-    public function testUksortThrowsException()
-    {
-        $document = [
-            'array' => [1, 2, 3],
-            'object' => ['foo' => 'bar'],
-        ];
-
-        $typeMap = [
-            'root' => 'object',
-            'document' => 'object',
-            'array' => 'array',
-        ];
-
-        $iterator = new TypeMapArrayIterator([$document], $typeMap);
-
-        $expectedDocument = (object) [
-            'array' => [1, 2, 3],
-            'object' => (object) ['foo' => 'bar'],
-        ];
-
-        $iterator->rewind();
-        $cmp_function = function($a, $b) {
-            return $a;
-        };
-        $iterator->uksort($cmp_function(0, 1));
     }
 }


### PR DESCRIPTION
Also added pedantic doc blocks akin to what existed in IndexInfo.

Since all of the bad method call tests were very similar (apart from a single method call at the end), this seemed like a ripe case for using a [data provider](https://phpunit.de/manual/current/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers). Initially, I thought about just making the method name dynamic, but since some of the methods took arbitrary arguments, I decided to provide a second value with the method's arguments (relevant for things like `offsetSet()` or `uasort()`).